### PR TITLE
修复sdkmanager0.9版本存在的问题

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:0.12.+'
-        classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.9.+'
+        classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.+'
     }
 }
 


### PR DESCRIPTION
sdkmanager0.9运行gradlew assemble时，每次都会提示'Support library repository outdated. Downloading update...'，在新版0.12中已修复。